### PR TITLE
small update to avoid error when model isn't on hf leaderboard

### DIFF
--- a/metadata/collect_integrated_model_scores.py
+++ b/metadata/collect_integrated_model_scores.py
@@ -5,6 +5,7 @@ import argparse
 import torch
 from datetime import datetime
 import json
+import os
 
 DEVICE = "cuda:0" if torch.cuda.is_available() else "cpu"
 
@@ -22,17 +23,22 @@ def evaluate_with_harness(
     # setting it to a conservative value that should work in most cases
     for task in tasks:
         print(task)
-        command_task = command.format(model_name=model_name, task=task, device=DEVICE)
-        result = subprocess.run(
-            command_task.split(" "),
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        parsed_results = parse_harness_results(result.stdout, task, "acc")
-        if parsed_results != {}:  # TODO: how to get num examples
-            new_results[task] = {"x-shot": parsed_results}
+        try:
+            command_task = command.format(
+                model_name=model_name, task=task, device=DEVICE
+            )
+            result = subprocess.run(
+                command_task.split(" "),
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            parsed_results = parse_harness_results(result.stdout, task, "acc")
+            if parsed_results != {}:  # TODO: how to get num examples
+                new_results[task] = {"x-shot": parsed_results}
+        except:
+            print(f"Failed to evaluate {task}")
 
     return new_results
 
@@ -67,18 +73,29 @@ def parse_harness_results(
 
 
 def integrated_eval(
-    model_name: str, tasks: list[str], output_filename: str, overwrite: bool = False
+    model_name: str,
+    tasks: list[str],
+    output_filename: str,
+    overwrite: bool = False,
+    eval_harness_only: bool = False,
 ) -> None:
     """
     Evaluate a model on a set of tasks + any additional tasks found in the open llm leaderboard on huggingface.
     """
 
-    # Collect the model scores
-    model_scores, json_path = collect_model_scores_hf(
-        model_name, output_filename, overwrite
-    )
-    evaled_datasets = set(model_scores["results"]["harness"].keys())
-    remaining_tasks = set(tasks) - set(evaled_datasets)
+    if not eval_harness_only:
+        # Collect the model scores
+        model_scores, json_path = collect_model_scores_hf(
+            model_name, output_filename, overwrite
+        )
+        evaled_datasets = set(model_scores["results"]["harness"].keys())
+        remaining_tasks = set(tasks) - set(evaled_datasets)
+    else:
+        model_scores = {"model_name": model_name, "results": {"harness": {}}}
+        remaining_tasks = set(tasks)
+        json_path = os.path.join(
+            output_filename, f"results_{model_name.replace('/', '_')}.json"
+        )
 
     # Evaluate the model on the tasks
     new_results = evaluate_with_harness(model_name, remaining_tasks, output_filename)
@@ -118,10 +135,17 @@ if __name__ == "__main__":
         help="The file containing the tasks, one per line",
         default="metadata/eval_harness_tasks.txt",
     )
+    parser.add_argument(
+        "--eval_harness_only",
+        action="store_true",
+        help="Whether to only evaluate the model on the tasks in the eval harness",
+    )
 
     args = parser.parse_args()
     with open(args.tasks_file, "r") as f:
         # tasks can also be commented out with #
         tasks = [l.strip() for l in f.readlines() if l[0] != "#"]
 
-    integrated_eval(args.model_name, tasks, args.output_dir, args.overwrite)
+    integrated_eval(
+        args.model_name, tasks, args.output_dir, args.overwrite, args.eval_harness_only
+    )

--- a/metadata/collect_model_scores_hf.py
+++ b/metadata/collect_model_scores_hf.py
@@ -107,7 +107,7 @@ def convert_results_format(results_json: dict) -> dict:
     return results_clean
 
 
-def get_model_scores(model_name: str) -> Optional[dict]:
+def get_model_scores(model_name: str) -> dict:
     openllm_url = "https://huggingface.co/datasets/open-llm-leaderboard/results"
     openllm_prefix = "open-llm-leaderboard-results"
     # Note: this repository contains all results on the openLLM leaderboard but it's not working currently (not loadable):
@@ -141,7 +141,11 @@ def get_model_scores(model_name: str) -> Optional[dict]:
 
             return results_clean
 
-    raise ValueError("Model scores not found")
+    return {
+        "model_name": model_name,
+        "last_updated": None,
+        "results": {"harness": {}},
+    }
 
 
 def main(model_name: str, output_dir: str, overwrite: bool) -> tuple[dict, str]:


### PR DESCRIPTION
## Description

I had this on my branch but forgot to include in a PR/previous PR. There was a bug where if a model wasn't on the hf leaderboard, we don't add it, but we should add eval harness results even if they're not on the hf leaderboard.

## References