### PR TITLE
Add visualization for feature importance (shap)

### DIFF
--- a/performance_prediction/train_xgboost.py
+++ b/performance_prediction/train_xgboost.py
@@ -14,7 +14,6 @@ import shap
 import matplotlib.pyplot as plt
 
 
-
 def fit_regressor(reg, train_feats, train_labels):
     reg.fit(train_feats, train_labels)
     return reg
@@ -184,7 +183,6 @@ if __name__ == "__main__":
     )
 
     test_predictions = model.predict(test_feats, output_margin=True)
-
 
     print(
         f"Model Hyperparameters:\n Learning Rate: {args.lr}\n Max Depth: {args.max_depth}\n Number of Estimators: {args.n_estimators}"


### PR DESCRIPTION
## Description

Adds a basic visualization of xgboost feature importance through the shap library, since xgboost's feature importance doesn't indicate the directionality of importance.

Example plot:
![shap_hellaswag_10-shot_acc](https://github.com/nightingal3/llm-pretraining-behaviours/assets/19615708/66c06a22-f6b3-41e9-930e-2da9aa257782)


## References

- Part of https://github.com/nightingal3/llm-pretraining-behaviours/issues/48